### PR TITLE
#103 [HOTFIX] prevent multiple clicks on folder

### DIFF
--- a/src/stateful_components/Drive/Drive.js
+++ b/src/stateful_components/Drive/Drive.js
@@ -154,6 +154,7 @@ class Drive extends React.Component {
     }
 
     followPath(path, event = {}) {
+        if (this.props.loadFolder) return;
         const { selectedItems, setCurrentPath, setSelection } = this.props;
         if (isCmdPressed(event) && selectedItems.includes(path)) {
             const newSelection = selectedItems.filter((item) => item !== path);
@@ -622,6 +623,7 @@ const mapStateToProps = (state) => {
         loadDeletion: state.app.loadDeletion,
         clipboard: state.app.clipboard,
         loadPaste: state.app.loadPaste,
+        loadFolder: state.app.loadFolder,
     };
 };
 


### PR DESCRIPTION
## Related Ticket/Issue
#103 

## Description
Prevent multiple breadcrumbs when clicking a folder multiple times

