### PR TITLE
[HOTFIX] return to drive view when clicking on breadcrumb

### DIFF
--- a/src/stateful_components/Drive/Drive.js
+++ b/src/stateful_components/Drive/Drive.js
@@ -465,7 +465,10 @@ class Drive extends React.Component {
         const toolbarLeft = webId ? (
             <div className={styles.breadcrumbsContainer}>
                 <Breadcrumbs
-                    onClick={setCurrentPath}
+                    onClick={(path) => {
+                        setCurrentPath(path);
+                        this.setState({ file: null });
+                    }}
                     breadcrumbs={
                         currentPath ? getBreadcrumbsFromUrl(currentPath) : null
                     }


### PR DESCRIPTION
## Related Ticket/Issue
#150 

## Description
Fix click on BReadcrumb when in file viewer